### PR TITLE
New winrm upload functionality

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
             }
         }
 
-        stage('Unit Tests) {
+        stage('Unit Tests') {
             steps {
                 parallel(
                     'Python2.7': { withPythonEnvironment(PYTHON_2_7_ENVIRONMENT_PATH, 'pytest -v --junitxml=unit-python-2.7.xml --cov=vcdriver --cov-fail-under 100 test/unit') },
@@ -62,7 +62,7 @@ pipeline {
             }
         }
 
-        stage('Integration Tests) {
+        stage('Integration Tests') {
             steps {
                 parallel(
                     'Python2.7': { withPythonEnvironment(PYTHON_2_7_ENVIRONMENT_PATH, 'vcdriver_test_folder="Vcdriver Tests Python 2.7" pytest -v -s --junitxml=integration-python-2.7.xml test/integration') },

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,18 +51,18 @@ pipeline {
             steps {
                 parallel(
                     'Python2.7': {
-                        dir('testing/unit/Python2.7') {
+                        dir('test/unit/Python2.7') {
                             withPythonEnvironment(
                                 PYTHON_2_7_ENVIRONMENT_PATH,
-                                'pytest -v --junitxml=testing/unit/unit-python-2.7.xml --cov=vcdriver --cov-fail-under 100 test/unit'
+                                'pytest -v --junitxml=../unit-python-2.7.xml --cov=vcdriver --cov-fail-under 100 ../'
                             )
                         }
                     },
                     'python3.5': {
-                        dir('testing/unit/Python3.5') {
+                        dir('test/unit/Python3.5') {
                             withPythonEnvironment(
                                 PYTHON_3_5_ENVIRONMENT_PATH,
-                                'pytest -v --junitxml=testing/unit/unit-python-3.5.xml --cov=vcdriver --cov-fail-under 100 test/unit'
+                                'pytest -v --junitxml=../unit-python-3.5.xml --cov=vcdriver --cov-fail-under 100 ../'
                             )
                         }
                     }
@@ -70,8 +70,8 @@ pipeline {
             }
             post {
                 always {
-                    junit 'testing/unit/unit-python-2.7.xml'
-                    junit 'testing/unit/unit-python-3.5.xml'
+                    junit 'test/unit/unit-python-2.7.xml'
+                    junit 'test/unit/unit-python-3.5.xml'
                 }
             }
         }
@@ -80,7 +80,7 @@ pipeline {
             steps {
                 parallel(
                     'Python2.7': {
-                        dir('testing/integration/Python2.7') {
+                        dir('test/integration/Python2.7') {
                             withVcdriverConfig {
                                 withPythonEnvironment(
                                     PYTHON_2_7_ENVIRONMENT_PATH,
@@ -90,7 +90,7 @@ pipeline {
                         }
                     },
                     'python3.5': {
-                        dir('testing/integration/Python3.5') {
+                        dir('test/integration/Python3.5') {
                             withVcdriverConfig {
                                 withPythonEnvironment(
                                     PYTHON_3_5_ENVIRONMENT_PATH,
@@ -103,8 +103,8 @@ pipeline {
             }
             post {
                 always {
-                    junit 'testing/integration/integration-python-2.7.xml'
-                    junit 'testing/integration/integration-python-3.5.xml'
+                    junit 'test/integration/integration-python-2.7.xml'
+                    junit 'test/integration/integration-python-3.5.xml'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,8 +65,8 @@ pipeline {
         stage('Integration Tests') {
             steps {
                 parallel(
-                    'Python2.7': { withPythonEnvironment(PYTHON_2_7_ENVIRONMENT_PATH, 'vcdriver_test_folder="Vcdriver Tests Python 2.7" pytest -v -s --junitxml=integration-python-2.7.xml test/integration') },
-                    'python3.5': { withPythonEnvironment(PYTHON_3_5_ENVIRONMENT_PATH, 'vcdriver_test_folder="Vcdriver Tests Python 3.5" pytest -v -s --junitxml=integration-python-3.5.xml test/integration') }
+                    'Python2.7': { withVcdriverConfig { withPythonEnvironment(PYTHON_2_7_ENVIRONMENT_PATH, 'vcdriver_test_folder="Vcdriver Tests Python 2.7" pytest -v -s --junitxml=integration-python-2.7.xml test/integration') } },
+                    'python3.5': { withVcdriverConfig { withPythonEnvironment(PYTHON_3_5_ENVIRONMENT_PATH, 'vcdriver_test_folder="Vcdriver Tests Python 3.5" pytest -v -s --junitxml=integration-python-3.5.xml test/integration') } }
                 )
             }
             post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,7 +88,7 @@ pipeline {
                         allowMissing: true,
                         alwaysLinkToLastBuild: false,
                         keepAll: true,
-                        reportDir: 'testing/unit/Python2.7/htmlcov',
+                        reportDir: 'test/unit/Python2.7/htmlcov',
                         reportFiles: 'index.html',
                         reportName: 'UT Coverage'
                     ]
@@ -129,7 +129,7 @@ pipeline {
                         allowMissing: true,
                         alwaysLinkToLastBuild: false,
                         keepAll: true,
-                        reportDir: 'testing/integration/Python2.7/htmlcov',
+                        reportDir: 'test/integration/Python2.7/htmlcov',
                         reportFiles: 'index.html',
                         reportName: 'IT Coverage'
                     ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,6 +45,13 @@ pipeline {
 
     stages {
 
+        stage('Cleanup') {
+            steps {
+                sh 'git reset --hard'
+                sh 'git clean -dfx'
+            }
+        }
+
         stage('Setup') {
             steps {
                 parallel(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
                         dir('test/unit/Python2.7') {
                             withPythonEnvironment(
                                 PYTHON_2_7_ENVIRONMENT_PATH,
-                                'pytest -v --junitxml=../unit-python-2.7.xml --cov=vcdriver --cov-fail-under 100 ../'
+                                'pytest -v --junitxml=../unit-python-2.7.xml --cov=vcdriver --cov-report html --cov-fail-under 100 ../'
                             )
                         }
                     },
@@ -71,6 +71,14 @@ pipeline {
             }
             post {
                 always {
+                    publishHTML target: [
+                        allowMissing: true,
+                        alwaysLinkToLastBuild: false,
+                        keepAll: true,
+                        reportDir: 'testing/unit/Python2.7/htmlcov',
+                        reportFiles: 'index.html',
+                        reportName: 'UT Coverage'
+                    ]
                     junit 'test/unit/unit-python-2.7.xml'
                     junit 'test/unit/unit-python-3.5.xml'
                 }
@@ -85,7 +93,7 @@ pipeline {
                             withVcdriverConfig {
                                 withPythonEnvironment(
                                     PYTHON_2_7_ENVIRONMENT_PATH,
-                                    'vcdriver_test_folder="Vcdriver Tests Python 2.7" pytest -v -s --junitxml=../integration-python-2.7.xml ../'
+                                    'vcdriver_test_folder="Vcdriver Tests Python 2.7" pytest -v -s --junitxml=../integration-python-2.7.xml --cov=vcdriver --cov-report html ../'
                                 )
                             }
                         }
@@ -104,6 +112,14 @@ pipeline {
             }
             post {
                 always {
+                    publishHTML target: [
+                        allowMissing: true,
+                        alwaysLinkToLastBuild: false,
+                        keepAll: true,
+                        reportDir: 'testing/integration/Python2.7/htmlcov',
+                        reportFiles: 'index.html',
+                        reportName: 'IT Coverage'
+                    ]
                     junit 'test/integration/integration-python-2.7.xml'
                     junit 'test/integration/integration-python-3.5.xml'
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,12 @@ pipeline {
         cron(CRON_STRING)
     }
 
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '20'))
+        disableConcurrentBuilds()
+        timeout(time: 2, unit: 'HOURS')
+    }
+
     environment {
         vcdriver_test_unix_template = 'Ubuntu-14.04-32bit'
         vcdriver_test_windows_template = 'Windows-Server-2012'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,8 +65,26 @@ pipeline {
         stage('Integration Tests') {
             steps {
                 parallel(
-                    'Python2.7': { withVcdriverConfig { withPythonEnvironment(PYTHON_2_7_ENVIRONMENT_PATH, 'vcdriver_test_folder="Vcdriver Tests Python 2.7" pytest -v -s --junitxml=integration-python-2.7.xml test/integration') } },
-                    'python3.5': { withVcdriverConfig { withPythonEnvironment(PYTHON_3_5_ENVIRONMENT_PATH, 'vcdriver_test_folder="Vcdriver Tests Python 3.5" pytest -v -s --junitxml=integration-python-3.5.xml test/integration') } }
+                    'Python2.7': {
+                        cd('testing/integration/Python2.7') {
+                            withVcdriverConfig {
+                                withPythonEnvironment(
+                                    PYTHON_2_7_ENVIRONMENT_PATH,
+                                    'vcdriver_test_folder="Vcdriver Tests Python 2.7" pytest -v -s --junitxml=integration-python-2.7.xml test/integration'
+                                )
+                            }
+                        }
+                    },
+                    'python3.5': {
+                        cd('testing/integration/Python3.5') {
+                            withVcdriverConfig {
+                                withPythonEnvironment(
+                                    PYTHON_3_5_ENVIRONMENT_PATH,
+                                    'vcdriver_test_folder="Vcdriver Tests Python 3.5" pytest -v -s --junitxml=integration-python-3.5.xml test/integration'
+                                )
+                            }
+                        }
+                    }
                 )
             }
             post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,7 +66,7 @@ pipeline {
             steps {
                 parallel(
                     'Python2.7': {
-                        cd('testing/integration/Python2.7') {
+                        dir('testing/integration/Python2.7') {
                             withVcdriverConfig {
                                 withPythonEnvironment(
                                     PYTHON_2_7_ENVIRONMENT_PATH,
@@ -76,7 +76,7 @@ pipeline {
                         }
                     },
                     'python3.5': {
-                        cd('testing/integration/Python3.5') {
+                        dir('testing/integration/Python3.5') {
                             withVcdriverConfig {
                                 withPythonEnvironment(
                                     PYTHON_3_5_ENVIRONMENT_PATH,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,6 @@
 PYTHON_2_7_ENVIRONMENT_PATH = '/home/osiriumbot/.vcdriver-pyenv2/'
 PYTHON_3_5_ENVIRONMENT_PATH = '/home/osiriumbot/.vcdriver-pyenv3/'
+CRON_STRING = env.BRANCH_NAME == 'master' ? "0 0 * * *" : ""
 
 def withPythonEnvironment(path, command) {
     sh '. ' + path + 'bin/activate && ' + command
@@ -28,7 +29,7 @@ pipeline {
     }
 
     triggers {
-        cron("0 0 * * *")
+        cron(CRON_STRING)
     }
 
     environment {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,14 +50,14 @@ pipeline {
         stage('Unit Tests') {
             steps {
                 parallel(
-                    'Python2.7': { withPythonEnvironment(PYTHON_2_7_ENVIRONMENT_PATH, 'pytest -v --junitxml=unit-python-2.7.xml --cov=vcdriver --cov-fail-under 100 test/unit') },
-                    'python3.5': { withPythonEnvironment(PYTHON_3_5_ENVIRONMENT_PATH, 'pytest -v --junitxml=unit-python-3.5.xml --cov=vcdriver --cov-fail-under 100 test/unit') }
+                    'Python2.7': { withPythonEnvironment(PYTHON_2_7_ENVIRONMENT_PATH, 'pytest -v --junitxml=testing/unit/unit-python-2.7.xml --cov=vcdriver --cov-fail-under 100 test/unit') },
+                    'python3.5': { withPythonEnvironment(PYTHON_3_5_ENVIRONMENT_PATH, 'pytest -v --junitxml=testing/unit/unit-python-3.5.xml --cov=vcdriver --cov-fail-under 100 test/unit') }
                 )
             }
             post {
                 always {
-                    junit 'unit-python-2.7.xml'
-                    junit 'unit-python-3.5.xml'
+                    junit 'testing/unit/unit-python-2.7.xml'
+                    junit 'testing/unit/unit-python-3.5.xml'
                 }
             }
         }
@@ -70,7 +70,7 @@ pipeline {
                             withVcdriverConfig {
                                 withPythonEnvironment(
                                     PYTHON_2_7_ENVIRONMENT_PATH,
-                                    'vcdriver_test_folder="Vcdriver Tests Python 2.7" pytest -v -s --junitxml=integration-python-2.7.xml test/integration'
+                                    'vcdriver_test_folder="Vcdriver Tests Python 2.7" pytest -v -s --junitxml=../integration-python-2.7.xml ../'
                                 )
                             }
                         }
@@ -80,7 +80,7 @@ pipeline {
                             withVcdriverConfig {
                                 withPythonEnvironment(
                                     PYTHON_3_5_ENVIRONMENT_PATH,
-                                    'vcdriver_test_folder="Vcdriver Tests Python 3.5" pytest -v -s --junitxml=integration-python-3.5.xml test/integration'
+                                    'vcdriver_test_folder="Vcdriver Tests Python 3.5" pytest -v -s --junitxml=../integration-python-3.5.xml ../'
                                 )
                             }
                         }
@@ -89,8 +89,8 @@ pipeline {
             }
             post {
                 always {
-                    junit 'integration-python-2.7.xml'
-                    junit 'integration-python-3.5.xml'
+                    junit 'testing/integration/integration-python-2.7.xml'
+                    junit 'testing/integration/integration-python-3.5.xml'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,8 +50,22 @@ pipeline {
         stage('Unit Tests') {
             steps {
                 parallel(
-                    'Python2.7': { withPythonEnvironment(PYTHON_2_7_ENVIRONMENT_PATH, 'pytest -v --junitxml=testing/unit/unit-python-2.7.xml --cov=vcdriver --cov-fail-under 100 test/unit') },
-                    'python3.5': { withPythonEnvironment(PYTHON_3_5_ENVIRONMENT_PATH, 'pytest -v --junitxml=testing/unit/unit-python-3.5.xml --cov=vcdriver --cov-fail-under 100 test/unit') }
+                    'Python2.7': {
+                        dir('testing/unit/Python2.7') {
+                            withPythonEnvironment(
+                                PYTHON_2_7_ENVIRONMENT_PATH,
+                                'pytest -v --junitxml=testing/unit/unit-python-2.7.xml --cov=vcdriver --cov-fail-under 100 test/unit'
+                            )
+                        }
+                    },
+                    'python3.5': {
+                        dir('testing/unit/Python3.5') {
+                            withPythonEnvironment(
+                                PYTHON_3_5_ENVIRONMENT_PATH,
+                                'pytest -v --junitxml=testing/unit/unit-python-3.5.xml --cov=vcdriver --cov-fail-under 100 test/unit'
+                            )
+                        }
+                    }
                 )
             }
             post {

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
-include CHANGELOG
 include LICENSE
 include README.rst
 include requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -10,11 +10,11 @@ Vcdriver is a wrapper around pyvmomi that lets you manage virtual machines on yo
 
 - Snapshot management.
 
-- SSH protocol for remote commands (Only for Unix, Requires the SSH service).
+- Remote management:
 
-- SFTP protocol for file transfers (Only for Unix, Requires the SSH service).
-
-- WinRM protocol for remote commands on Windows machines (Only for Windows, requires the WinRM service).
+  - SSH protocol for remote commands (Requires the SSH service).
+  - SFTP protocol for file transfers (Requires the SSH service).
+  - WinRM protocol for remote commands and file transfer on Windows machines (Requires the WinRM service).
 
 How does it work underneath?
 ============================

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(
-    version='3.5.2',
+    version='3.6.0',
     name='vcdriver',
     description='A vcenter driver based on pyvmomi, fabric and pywinrm',
     url='https://github.com/Osirium/vcdriver',

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -71,14 +71,15 @@ def files():
             pass
 
 
-def test_ip(vms):
-    for vm in vms.values():
-        socket.inet_aton(vm.ip())
-
-
+@pytest.mark.xfail(reason='Jenkins AD user should not be allowed to do this')
 def test_autostart(vms):
     for vm in vms.values():
         vm.set_autostart()
+
+
+def test_ip(vms):
+    for vm in vms.values():
+        socket.inet_aton(vm.ip())
 
 
 def test_ssh(vms):

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -38,6 +38,24 @@ def wait_for_power_state_or_die(vm_object, state):
 
 
 @pytest.fixture(scope='module')
+def vms():
+    load(os.getenv('vcdriver_test_config_file'))
+    unix = VirtualMachine(template=os.getenv('vcdriver_test_unix_template'))
+    windows = VirtualMachine(
+        template=os.getenv('vcdriver_test_windows_template')
+    )
+    vms = {'unix': unix, 'windows': windows}
+    for vm in vms.values():
+        try:
+            vm.find()
+            vm.destroy()
+        except NoObjectFound:
+            pass
+    with virtual_machines(vms.values()):
+        yield vms
+
+
+@pytest.fixture(scope='function')
 def files():
     os.makedirs(os.path.join('dir-0', 'dir-1', 'dir-2'))
     touch('file-0')
@@ -45,111 +63,15 @@ def files():
     touch(os.path.join('dir-0', 'dir-1', 'file-2'))
     touch(os.path.join('dir-0', 'dir-1', 'dir-2', 'file-3'))
     yield
-    try:
-        shutil.rmtree('dir-0')
-    except:
-        pass
-    try:
-        os.remove('file-0')
-    except:
-        pass
-
-
-@pytest.fixture(scope='function')
-def vms():
-    load(os.getenv('vcdriver_test_config_file'))
-    unix = VirtualMachine(
-        name='test-integration-vcdriver-unix',
-        template=os.getenv('vcdriver_test_unix_template')
-    )
-    windows = VirtualMachine(
-        name='test-integration-vcdriver-windows',
-        template=os.getenv('vcdriver_test_windows_template')
-    )
-    vms = {'unix': unix, 'windows': windows}
-    yield vms
-    for vm in vms.values():
+    for func, arg in ((shutil.rmtree, 'dir-0'), (os.remove, 'file-0')):
         try:
-            vm.find()
-            vm.destroy()
+            func(arg)
         except:
             pass
 
 
-def test_create_delete(vms):
-    for vm in vms.values():
-        assert vm.__getattribute__('_vm_object') is None
-        with pytest.raises(NotEnoughDiskSpace):
-            vm.create(vcdriver_data_store_threshold=99)
-        vm.create()
-        assert vm.__getattribute__('_vm_object') is not None
-        vm.create()
-        assert vm.__getattribute__('_vm_object') is not None
-        vm.destroy()
-        assert vm.__getattribute__('_vm_object') is None
-        vm.destroy()
-        assert vm.__getattribute__('_vm_object') is None
-
-
-def test_boot_methods(vms):
-    with virtual_machines(vms.values()):
-        for vm in vms.values():
-            vm_object = vm.__getattribute__('_vm_object')
-            wait_for_power_state_or_die(vm_object, 'poweredOn')
-            assert vm_object.summary.runtime.powerState == 'poweredOn'
-            vm.power_on()
-            wait_for_power_state_or_die(vm_object, 'poweredOn')
-            assert vm_object.summary.runtime.powerState == 'poweredOn'
-            vm.power_off()
-            wait_for_power_state_or_die(vm_object, 'poweredOff')
-            assert vm_object.summary.runtime.powerState == 'poweredOff'
-            vm.power_off()
-            wait_for_power_state_or_die(vm_object, 'poweredOff')
-            assert vm_object.summary.runtime.powerState == 'poweredOff'
-            vm.power_on()
-            vm.reset()
-            wait_for_power_state_or_die(vm_object, 'poweredOn')
-            assert vm_object.summary.runtime.powerState == 'poweredOn'
-            vm.shutdown()
-            wait_for_power_state_or_die(vm_object, 'poweredOff')
-            assert vm_object.summary.runtime.powerState == 'poweredOff'
-            vm.shutdown()
-            wait_for_power_state_or_die(vm_object, 'poweredOff')
-            assert vm_object.summary.runtime.powerState == 'poweredOff'
-            vm.power_on()
-            vm.reboot()
-            wait_for_power_state_or_die(vm_object, 'poweredOn')
-            assert vm_object.summary.runtime.powerState == 'poweredOn'
-
-
-def test_virtual_machines(vms):
-    for vm in vms.values():
-        with pytest.raises(NoObjectFound):
-            vm.find()
-    with virtual_machines(vms.values()):
-        for vm in vms.values():
-            vm.find()
-    for vm in vms.values():
-        with pytest.raises(NoObjectFound):
-            vm.find()
-
-
-def test_get_all_virtual_machines(vms):
-    vms['unix'].create()
-    assert len(get_all_virtual_machines()) >= 1
-
-
-def test_destroy_virtual_machines(vms):
-    for vm in vms.values():
-        vm.create()
-    for vm in destroy_virtual_machines(os.getenv('vcdriver_test_folder')):
-        with pytest.raises(NoObjectFound):
-            vm.find()
-
-
 def test_ip(vms):
     for vm in vms.values():
-        vm.create()
         socket.inet_aton(vm.ip())
 
 
@@ -159,14 +81,12 @@ def test_autostart(vms):
 
 
 def test_ssh(vms):
-    vms['unix'].create()
     assert vms['unix'].ssh('ls').return_code == 0
     with pytest.raises(SshError):
         vms['unix'].ssh('wrong-command-seriously')
 
 
-def test_upload_and_download(files, vms):
-    vms['unix'].create()
+def test_ssh_upload_and_download(files, vms):
     assert len(
         vms['unix'].upload(local_path='file-0', remote_path='file-0')
     ) == 1
@@ -188,18 +108,27 @@ def test_upload_and_download(files, vms):
         vms['unix'].upload(local_path='dir-0', remote_path='wrong-path')
 
 
-def test_winrm(files, vms):
-    vms['windows'].create()
+def test_winrm(vms):
     vms['windows'].winrm('ipconfig /all')
     # FIXME:
     # Due to this pywinrm bug: https://github.com/diyan/pywinrm/issues/111
-    # we need to split the integration tests depending on the major version
-    # Python 2: Everything works as expected
-    # Python 3: Failed scripts throw TypeError instead of WinRmError
-    # Python 3: WinRM upload does not work :(
+    # We need to split the integration tests depending on the major version
+    # Python 2: Failed scripts throw WinRmError
+    # Python 3: Failed scripts throw TypeError
     if sys.version_info[0] == 2:
         with pytest.raises(WinRmError):
             vms['windows'].winrm('ipconfig-wrong /wrong')
+    elif sys.version_info[0] == 3:
+        with pytest.raises(TypeError):
+            vms['windows'].winrm('ipconfig-wrong /wrong')
+
+
+def test_winrm_upload(files, vms):
+    # FIXME:
+    # Due to this pywinrm bug: https://github.com/diyan/pywinrm/issues/111
+    # We need to split the integration tests depending on the major version
+    # Python 3: WinRM upload does not work :(
+    if sys.version_info[0] == 2:
         vms['windows'].winrm_upload(
             local_path='file-0',
             remote_path='C:\\file-0'
@@ -210,27 +139,80 @@ def test_winrm(files, vms):
             '$(Get-FileHash -Algorithm SHA256 C:\\file-0).hash'
         )
         assert expected_sha256 == str(resulted_sha256.strip())
-    elif sys.version_info[0] == 3:
-        with pytest.raises(TypeError):
-            vms['windows'].winrm('ipconfig-wrong /wrong')
+
+
+def test_get_all_virtual_machines(vms):
+    vm_names = [vm.name for vm in get_all_virtual_machines()]
+    assert vms['unix'].name in vm_names
+    assert vms['windows'].name in vm_names
+
+
+def test_boot_methods(vms):
+    for vm in vms.values():
+        vm_object = vm._vm_object
+        wait_for_power_state_or_die(vm_object, 'poweredOn')
+        assert vm_object.summary.runtime.powerState == 'poweredOn'
+        vm.power_on()
+        wait_for_power_state_or_die(vm_object, 'poweredOn')
+        assert vm_object.summary.runtime.powerState == 'poweredOn'
+        vm.power_off()
+        wait_for_power_state_or_die(vm_object, 'poweredOff')
+        assert vm_object.summary.runtime.powerState == 'poweredOff'
+        vm.power_off()
+        wait_for_power_state_or_die(vm_object, 'poweredOff')
+        assert vm_object.summary.runtime.powerState == 'poweredOff'
+        vm.power_on()
+        vm.reset()
+        wait_for_power_state_or_die(vm_object, 'poweredOn')
+        assert vm_object.summary.runtime.powerState == 'poweredOn'
+        vm.shutdown()
+        wait_for_power_state_or_die(vm_object, 'poweredOff')
+        assert vm_object.summary.runtime.powerState == 'poweredOff'
+        vm.shutdown()
+        wait_for_power_state_or_die(vm_object, 'poweredOff')
+        assert vm_object.summary.runtime.powerState == 'poweredOff'
+        vm.power_on()
+        vm.reboot()
+        wait_for_power_state_or_die(vm_object, 'poweredOn')
+        assert vm_object.summary.runtime.powerState == 'poweredOn'
+
+
+def test_create_delete_find(vms):
+    for vm in vms.values():
+        assert vm._vm_object is not None
+        for _ in range(2):
+            vm.destroy()
+            assert vm._vm_object is None
+            with pytest.raises(NoObjectFound):
+                vm.find()
+            with pytest.raises(NotEnoughDiskSpace):
+                vm.create(vcdriver_data_store_threshold=99)
+        for _ in range(2):
+            vm.create()
+            assert vm._vm_object is not None
+            vm._vm_object = None
+            vm.find()
+            assert vm._vm_object is not None
+
+
+def test_destroy_virtual_machines(vms):
+    for vm in destroy_virtual_machines(os.getenv('vcdriver_test_folder')):
+        with pytest.raises(NoObjectFound):
+            vm.find()
+    for vm in vms.values():
+        vm._vm_object = None
+        vm.create()
 
 
 def test_snapshots(vms):
-    snapshot_name = 'test_snapshot'
+    snapshot_name = 'vcdriver_test_snapshot'
     for vm in vms.values():
-        vm.create()
         with pytest.raises(NoObjectFound):
             vm.find_snapshot(snapshot_name)
         vm.create_snapshot(snapshot_name, True)
         with pytest.raises(TooManyObjectsFound):
             vm.create_snapshot(snapshot_name, True)
         vm.find_snapshot(snapshot_name)
-    assert vms['unix'].ssh('touch banana').return_code == 0
-    assert vms['unix'].ssh('ls') == 'banana'
-    for vm in vms.values():
         vm.revert_snapshot(snapshot_name)
-    assert vms['unix'].ssh('ls') == ''
-    with snapshot(vms['unix']):
-        vms['unix'].ssh('touch banana')
-        assert vms['unix'].ssh('ls') == 'banana'
-    assert vms['unix'].ssh('ls') == ''
+        with snapshot(vm):
+            pass

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -2,6 +2,7 @@ import hashlib
 import os
 import shutil
 import socket
+import sys
 
 import pytest
 
@@ -11,7 +12,7 @@ from vcdriver.exceptions import (
     DownloadError,
     UploadError,
     SshError,
-    # WinRmError,
+    WinRmError,
     NotEnoughDiskSpace
 )
 from vcdriver.vm import (
@@ -27,7 +28,7 @@ from vcdriver.helpers import timeout_loop
 
 def touch(file_name):
     with open(file_name, 'wb') as f:
-        f.write("\0" * 50 * 1024)  # 50 kb files
+        f.write(b'\0' * 1024 * 5)  # 5 kb file
 
 
 def wait_for_power_state_or_die(vm_object, state):
@@ -190,22 +191,28 @@ def test_upload_and_download(files, vms):
 def test_winrm(files, vms):
     vms['windows'].create()
     vms['windows'].winrm('ipconfig /all')
-    with pytest.raises(Exception):
-        # FIXME:
-        # Due to this pywinrm bug: https://github.com/diyan/pywinrm/issues/111
-        # we cannot expect WinRmError, so we have to use the general Exception
-        vms['windows'].winrm('ipconfig-wrong /wrong')
-    vms['windows'].winrm_upload(
-        local_path='file-0',
-        remote_path='C:\\file-0'
-    )
-    with open('file-0', 'rb') as f:
-        expected_sha256 = hashlib.sha256(f.read()).hexdigest().upper()
-    _, resulted_sha256, _ = vms['windows'].winrm(
-        '$(Get-FileHash -Algorithm SHA256 C:\\file-0).hash'
-    )
-    assert expected_sha256 == str(resulted_sha256.strip())
-
+    # FIXME:
+    # Due to this pywinrm bug: https://github.com/diyan/pywinrm/issues/111
+    # we need to split the integration tests depending on the major version
+    # Python 2: Everything works as expected
+    # Python 3: Failed scripts throw TypeError instead of WinRmError
+    # Python 3: WinRM upload does not work :(
+    if sys.version_info[0] == 2:
+        with pytest.raises(WinRmError):
+            vms['windows'].winrm('ipconfig-wrong /wrong')
+        vms['windows'].winrm_upload(
+            local_path='file-0',
+            remote_path='C:\\file-0'
+        )
+        with open('file-0', 'rb') as f:
+            expected_sha256 = hashlib.sha256(f.read()).hexdigest().upper()
+        _, resulted_sha256, _ = vms['windows'].winrm(
+            '$(Get-FileHash -Algorithm SHA256 C:\\file-0).hash'
+        )
+        assert expected_sha256 == str(resulted_sha256.strip())
+    elif sys.version_info[0] == 3:
+        with pytest.raises(TypeError):
+            vms['windows'].winrm('ipconfig-wrong /wrong')
 
 def test_snapshots(vms):
     snapshot_name = 'test_snapshot'

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -33,7 +33,7 @@ def touch(file_name):
 
 def wait_for_power_state_or_die(vm_object, state):
     timeout_loop(
-        30, '', 1, True, lambda: vm_object.summary.runtime.powerState == state
+        300, '', 1, True, lambda: vm_object.summary.runtime.powerState == state
     )
 
 

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -214,6 +214,7 @@ def test_winrm(files, vms):
         with pytest.raises(TypeError):
             vms['windows'].winrm('ipconfig-wrong /wrong')
 
+
 def test_snapshots(vms):
     snapshot_name = 'test_snapshot'
     for vm in vms.values():

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -39,6 +39,7 @@ def wait_for_power_state_or_die(vm_object, state):
 
 @pytest.fixture(scope='module')
 def vms():
+    os.environ['vcdriver_folder'] = os.getenv('vcdriver_test_folder')
     load(os.getenv('vcdriver_test_config_file'))
     unix = VirtualMachine(template=os.getenv('vcdriver_test_unix_template'))
     windows = VirtualMachine(

--- a/test/unit/test_vm.py
+++ b/test/unit/test_vm.py
@@ -427,15 +427,21 @@ def test_virtual_machine_winrm_timeout(run_ps, connection):
         vm.winrm('script', dict())
 
 
+@mock.patch('vcdriver.vm.os.stat')
 @mock.patch('vcdriver.vm.open')
 @mock.patch('vcdriver.vm.connection')
 @mock.patch.object(winrm.Session, 'run_ps')
-def test_virtual_machine_winrm_upload_success(run_ps, connection, open):
+def test_virtual_machine_winrm_upload_success(
+        run_ps, connection, open, os_stat
+):
+    st_size_mock = mock.Mock()
+    st_size_mock.st_size = 3
+    os_stat.return_value = st_size_mock
     code_mock = mock.Mock()
     code_mock.status_code = 0
     run_ps.return_value = code_mock
     read_mock = mock.Mock
-    read_mock.read = lambda x: b'\0\0\0'
+    read_mock.read = lambda x, y: b'\0\0\0'
     open.__enter__ = read_mock
     open.__exit__ = mock.Mock()
     os.environ['vcdriver_vm_winrm_username'] = 'user'
@@ -449,15 +455,19 @@ def test_virtual_machine_winrm_upload_success(run_ps, connection, open):
     assert vm.winrm_upload('whatever', 'whatever', step=2) is None
 
 
+@mock.patch('vcdriver.vm.os.stat')
 @mock.patch('vcdriver.vm.open')
 @mock.patch('vcdriver.vm.connection')
 @mock.patch.object(winrm.Session, 'run_ps')
-def test_virtual_machine_winrm_upload_fail(run_ps, connection, open):
+def test_virtual_machine_winrm_upload_fail(run_ps, connection, open, os_stat):
+    st_size_mock = mock.Mock()
+    st_size_mock.st_size = 3
+    os_stat.return_value = st_size_mock
     code_mock = mock.Mock()
     code_mock.status_code = 1
     run_ps.return_value = code_mock
     read_mock = mock.Mock
-    read_mock.read = lambda x: b'\0\0\0'
+    read_mock.read = lambda x, y: b'\0\0\0'
     open.__enter__ = read_mock
     open.__exit__ = mock.Mock()
     os.environ['vcdriver_vm_winrm_username'] = 'user'

--- a/test/unit/test_vm.py
+++ b/test/unit/test_vm.py
@@ -427,6 +427,25 @@ def test_virtual_machine_winrm_timeout(run_ps, connection):
         vm.winrm('script', dict())
 
 
+@mock.patch('vcdriver.vm.open')
+@mock.patch('vcdriver.vm.connection')
+@mock.patch.object(winrm.Session, 'run_ps')
+def test_virtual_machine_winrm_upload(run_ps, connection, open):
+    read_mock = mock.Mock
+    read_mock.read = lambda x: '\0\0'
+    open.__enter__ = read_mock
+    open.__exit__ = mock.Mock()
+    os.environ['vcdriver_vm_winrm_username'] = 'user'
+    os.environ['vcdriver_vm_winrm_password'] = 'pass'
+    load()
+    vm = VirtualMachine()
+    assert vm.winrm_upload('whatever', 'whatever') is None
+    vm_object_mock = mock.MagicMock()
+    vm_object_mock.summary.guest.ipAddress = '127.0.0.1'
+    vm.__setattr__('_vm_object', vm_object_mock)
+    assert vm.winrm_upload('whatever', 'whatever', step=1) is None
+
+
 @mock.patch('vcdriver.vm.wait_for_vcenter_task')
 def test_virtual_machine_find_snapshot(wait_for_vcenter_task):
     fake_snapshots = [mock.MagicMock(), mock.MagicMock(), mock.MagicMock()]

--- a/test/unit/test_vm.py
+++ b/test/unit/test_vm.py
@@ -432,7 +432,7 @@ def test_virtual_machine_winrm_timeout(run_ps, connection):
 @mock.patch.object(winrm.Session, 'run_ps')
 def test_virtual_machine_winrm_upload(run_ps, connection, open):
     read_mock = mock.Mock
-    read_mock.read = lambda x: '\0\0'
+    read_mock.read = lambda x: b'\0\0'
     open.__enter__ = read_mock
     open.__exit__ = mock.Mock()
     os.environ['vcdriver_vm_winrm_username'] = 'user'

--- a/test/unit/test_vm.py
+++ b/test/unit/test_vm.py
@@ -465,6 +465,7 @@ def test_virtual_machine_winrm_upload_fail(run_ps, connection, open, os_stat):
     os_stat.return_value = st_size_mock
     code_mock = mock.Mock()
     code_mock.status_code = 1
+    code_mock.std_err = 'Whatever'.encode('ascii')
     run_ps.return_value = code_mock
     read_mock = mock.Mock
     read_mock.read = lambda x, y: b'\0\0\0'
@@ -478,6 +479,36 @@ def test_virtual_machine_winrm_upload_fail(run_ps, connection, open, os_stat):
     vm_object_mock.summary.guest.ipAddress = '127.0.0.1'
     vm.__setattr__('_vm_object', vm_object_mock)
     with pytest.raises(WinRmError):
+        vm.winrm_upload('whatever', 'whatever', step=2)
+
+
+@mock.patch('vcdriver.vm.os.stat')
+@mock.patch('vcdriver.vm.open')
+@mock.patch('vcdriver.vm.connection')
+@mock.patch.object(winrm.Session, 'run_ps')
+def test_virtual_machine_winrm_upload_timeout(
+        run_ps, connection, open, os_stat
+):
+    st_size_mock = mock.Mock()
+    st_size_mock.st_size = 3
+    os_stat.return_value = st_size_mock
+    code_mock = mock.Mock()
+    code_mock.status_code = 1
+    code_mock.std_err = 'Blah is being used by another process'.encode('ascii')
+    run_ps.return_value = code_mock
+    read_mock = mock.Mock
+    read_mock.read = lambda x, y: b'\0\0\0'
+    open.__enter__ = read_mock
+    open.__exit__ = mock.Mock()
+    os.environ['vcdriver_vm_winrm_username'] = 'user'
+    os.environ['vcdriver_vm_winrm_password'] = 'pass'
+    load()
+    vm = VirtualMachine()
+    vm_object_mock = mock.MagicMock()
+    vm_object_mock.summary.guest.ipAddress = '127.0.0.1'
+    vm.__setattr__('_vm_object', vm_object_mock)
+    vm.timeout = 1
+    with pytest.raises(TimeoutError):
         vm.winrm_upload('whatever', 'whatever', step=2)
 
 

--- a/vcdriver/exceptions.py
+++ b/vcdriver/exceptions.py
@@ -31,10 +31,11 @@ class TimeoutError(Exception):
 
 
 class RemoteCommandError(Exception):
-    def __init__(self, command, return_code):
+    def __init__(self, command, return_code, std_out='', std_err=''):
         super(RemoteCommandError, self).__init__(
-            'Remote execution of "{}" failed with exit code {}'.format(
-                command, return_code
+            'Remote execution of "{}" failed with exit code {}. '
+            'STDOUT: {}. STDERR: {}.'.format(
+                command, return_code, std_out, std_err
             )
         )
 

--- a/vcdriver/vm.py
+++ b/vcdriver/vm.py
@@ -38,7 +38,7 @@ from vcdriver.helpers import (
 class VirtualMachine(object):
     def __init__(
             self,
-            name=str(uuid.uuid4()),
+            name=None,
             template=None,
             timeout=3600
     ):
@@ -49,7 +49,7 @@ class VirtualMachine(object):
 
         _vm_object: An internal instance of the vcenter vm object
         """
-        self.name = name
+        self.name = name or str(uuid.uuid4())
         self.template = template
         self.timeout = timeout
         self._vm_object = None

--- a/vcdriver/vm.py
+++ b/vcdriver/vm.py
@@ -224,7 +224,7 @@ class VirtualMachine(object):
                 else:
                     result = run(command)
                 if result.failed:
-                    raise SshError(command, result.return_code)
+                    raise SshError(command, result.return_code, result.stdout)
                 return result
 
     @configurable([
@@ -342,7 +342,7 @@ class VirtualMachine(object):
             styled_print(Fore.GREEN)(stdout)
             if status != 0:
                 styled_print(Fore.RED)(stderr)
-                raise WinRmError(script, status)
+                raise WinRmError(script, status, stdout, stderr)
             else:
                 return status, stdout, stderr
 
@@ -389,9 +389,11 @@ class VirtualMachine(object):
                         )
                     )
                     result = winrm_session.run_ps(script)
-                    status_code = result.status_code
-                    if status_code != 0:
-                        raise WinRmError(script, status_code)
+                    code = result.status_code
+                    stdout = result.std_out.decode('ascii')
+                    stderr = result.std_err.decode('ascii')
+                    if code != 0:
+                        raise WinRmError(script, code, stdout, stderr)
                     transferred = i + step
                     if transferred > size:
                         transferred = size

--- a/vcdriver/vm.py
+++ b/vcdriver/vm.py
@@ -374,43 +374,44 @@ class VirtualMachine(object):
                 operation_timeout_sec=self.timeout,
                 **winrm_kwargs
             )
-            with open(local_path, 'rb') as f:
-                contents = f.read()
-                size = len(contents)
+            size = os.stat(local_path).st_size
             winrm_session.run_ps(
                 'if (Test-Path {0}) {{ Remove-Item {0} }}'.format(remote_path)
             )
-            for i in range(0, size, step):
-                script = (
-                    'add-content -value '
-                    '$([System.Convert]::FromBase64String("{}")) '
-                    '-encoding byte -path {}'.format(
-                        base64.b64encode(contents[i:i + step]),
-                        remote_path
+            with open(local_path, 'rb') as f:
+                for i in range(0, size, step):
+                    script = (
+                        'add-content -value '
+                        '$([System.Convert]::FromBase64String("{}")) '
+                        '-encoding byte -path {}'.format(
+                            base64.b64encode(f.read(step)),
+                            remote_path
+                        )
                     )
-                )
-                result = winrm_session.run_ps(script)
-                status_code = result.status_code
-                if status_code != 0:
-                    raise WinRmError(script, status_code)
-                transferred = i + step
-                if transferred > size:
-                    transferred = size
-                progress_blocks = transferred * 30 // size
-                percentage_string = str((100 * transferred) // size) + ' %'
-                percentage_string = (
-                    ' ' * (5 - len(percentage_string)) + percentage_string
-                )
-                print(
-                    '\r{} ... [{}{}] {}'.format(
-                        'Copying "{}" to "{}"'.format(local_path, remote_path),
-                        '=' * progress_blocks,
-                        ' ' * (30 - progress_blocks),
-                        percentage_string
-                    ),
-                    end=''
-                )
-                sys.stdout.flush()
+                    result = winrm_session.run_ps(script)
+                    status_code = result.status_code
+                    if status_code != 0:
+                        raise WinRmError(script, status_code)
+                    transferred = i + step
+                    if transferred > size:
+                        transferred = size
+                    progress_blocks = transferred * 30 // size
+                    percentage_string = str((100 * transferred) // size) + ' %'
+                    percentage_string = (
+                        ' ' * (5 - len(percentage_string)) + percentage_string
+                    )
+                    print(
+                        '\r{} ... [{}{}] {}'.format(
+                            'Copying "{}" to "{}"'.format(
+                                local_path, remote_path
+                            ),
+                            '=' * progress_blocks,
+                            ' ' * (30 - progress_blocks),
+                            percentage_string
+                        ),
+                        end=''
+                    )
+                    sys.stdout.flush()
             print('')
 
     def find_snapshot(self, name):

--- a/vcdriver/vm.py
+++ b/vcdriver/vm.py
@@ -1,3 +1,4 @@
+import base64
 import contextlib
 import os
 import uuid
@@ -341,6 +342,50 @@ class VirtualMachine(object):
                 raise WinRmError(script, status)
             else:
                 return status, stdout, stderr
+
+    @configurable([
+        ('Virtual Machine Remote Management', 'vcdriver_vm_winrm_username'),
+        ('Virtual Machine Remote Management', 'vcdriver_vm_winrm_password')
+    ])
+    def winrm_upload(
+            self, remote_path, local_path, step=1024, winrm_kwargs=dict(),
+            **kwargs
+    ):
+        """
+        Copy a file through winrm
+        :param remote_path: The remote location
+        :param local_path: The local local
+        :param step: Number of bytes to send in each chunk
+        :param winrm_kwargs: The pywinrm Protocol class kwargs
+
+        :return: A tuple with the status code, the stdout and the stderr
+        """
+        winrm_session = winrm.Session(
+            target=self.ip(),
+            auth=(
+                kwargs['vcdriver_vm_winrm_username'],
+                kwargs['vcdriver_vm_winrm_password'],
+            ),
+            read_timeout_sec=self.timeout+1,
+            operation_timeout_sec=self.timeout,
+            **winrm_kwargs
+        )
+        with open(local_path, 'rb') as f:
+            contents = f.read()
+        for i in range(0, len(contents), step):
+            winrm_session.run_ps(
+                """
+$filePath = "{}"
+$s = @"
+{}
+"@
+$data = [System.Convert]::FromBase64String($s)
+add-content -value $data -encoding byte -path $filePath
+                """.format(remote_path, base64.b64encode(contents[i:i+step]))
+            )
+        print('{} -> {} WINRM transfer successful'.format(
+            local_path, remote_path
+        ))
 
     def find_snapshot(self, name):
         """


### PR DESCRIPTION
Two threads here:

- New `winrm_upload` function:

  This allows file transfer through WinRM sreaming. It's not speedy for big binary files, but works well for 
  text/config files. There are unit and integration tests covering it.

  The origin of this PR is that we need to provide sysprep unattend.xml files to be able to change the SID 
  in windows machines in a fully automated way. It's a bit frustrating, but sysprep is the only supported 
  tool that performs that task, and the only way to fully automate it is to provide config in xml form that 
  gets read after the reboot (Otherwise you get undesired side effects like Administrator password reset 
  that basically breaks the downstream of your automation pipeline). The reason behind changing SID's 
  is that they have to be unique if you want to have them in the same domain, and cloning windows 
  boxes from a Vsphere template sadly gives them the same SID. It all looks a bit too complicated, but 
  this opens a big door for further Windows automation.

- Fix and improve integration tests:
  I have fixed some race conditions that appeared recently in the integration tests. I've also made 
  them faster by optimizing the number of times we create and delete the vms and I've made Jenkins to 
  run them in parallel (Python 2 and 3). Builds are now ~5 times faster: 14 minutes against 1 hour and 6 
  minutes.