### PR TITLE
Display last exception str on timeouts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(
-    version='4.1.0',
+    version='4.2.0',
     name='osirium-vcdriver',
     description='A vcenter driver based on pyvmomi, fabric and pywinrm',
     url='https://github.com/Osirium/vcdriver',

--- a/vcdriver/helpers.py
+++ b/vcdriver/helpers.py
@@ -112,6 +112,7 @@ def timeout_loop(
 
     :raise: TimeoutError: If the timeout is reached
     """
+    error = None
     if not quiet:
         print('Waiting for [{}] ... '.format(description), end='')
         sys.stdout.flush()
@@ -119,12 +120,17 @@ def timeout_loop(
     start = time.time()
     while countdown >= 0:
         callback_start = time.time()
-        if callback(*callback_args, **callback_kwargs):
-            break
+        try:
+            if callback(*callback_args, **callback_kwargs):
+                break
+        except Exception as e:
+            error = e
         callback_time = time.time() - callback_start
         time.sleep(seconds_until_retry)
         countdown = countdown - seconds_until_retry - callback_time
     if countdown <= 0:
+        if error:
+            description = '{}. {}'.format(description, str(error))
         raise TimeoutError(description, timeout)
     if not quiet:
         print(datetime.timedelta(seconds=time.time() - start))
@@ -235,13 +241,10 @@ def check_ssh_service(host, username, password):
     :param username: SSH username
     :param password: SSH password
     """
-    try:
-        with hide_std():
-            with fabric_context(host, username, password):
-                run('')
-            return True
-    except:
-        return False
+    with hide_std():
+        with fabric_context(host, username, password):
+            run('')
+    return True
 
 
 def check_winrm_service(host, username, password, **kwargs):
@@ -252,9 +255,6 @@ def check_winrm_service(host, username, password, **kwargs):
     :param password: WinRM password
     :param kwargs: pywinrm Protocol kwargs
     """
-    try:
-        with hide_std():
-            winrm.Session(host, (username, password), **kwargs).run_ps('ls')
-        return True
-    except:
-        return False
+    with hide_std():
+        winrm.Session(host, (username, password), **kwargs).run_ps('ls')
+    return True


### PR DESCRIPTION
Instead of swallowing the errors, display the last exception traceback alongside the timeout exception description.