### PR TITLE
catch ManagedObjectNotFound when getting all virtual machines

### DIFF
--- a/vcdriver/vm.py
+++ b/vcdriver/vm.py
@@ -718,10 +718,20 @@ def get_all_virtual_machines():
 
     :return: A list with all the VirtualMachine objects
     """
-    machines = []
-    for vm_object in get_all_vcenter_objects(connection(), vim.VirtualMachine):
-        machine = VirtualMachine()
-        machine.__setattr__('_vm_object', vm_object)
-        machine.name = vm_object.summary.config.name
-        machines.append(machine)
-    return machines
+
+    def process(vm_object):
+        try:
+            name = vm_object.summary.config.name
+        except vim.ManagedObjectNotFound:
+            return None
+
+        machine = VirtualMachine(name=name)
+        machine._vm_object = vm_object
+        return machine
+
+    return [
+        machine
+        for vm_object in get_all_vcenter_objects(connection(), vim.VirtualMachine)
+        for machine in (process(vm_object),)
+        if machine is not None
+    ]


### PR DESCRIPTION
```
[2020-05-06T23:02:37.411Z]   File "/home/osirium_support/****_slave/.cleanup-pipeline-pr-3882-pyenv3/lib/python3.7/site-packages/vcdriver/vm.py", line 781, in get_all_virtual_machines
[2020-05-06T23:02:37.411Z]     machine.name = vm_object.summary.config.name
[2020-05-06T23:02:37.411Z]   File "/home/osirium_support/****_slave/.cleanup-pipeline-pr-3882-pyenv3/lib/python3.7/site-packages/pyVmomi/VmomiSupport.py", line 700, in __call__
[2020-05-06T23:02:37.411Z]     return self.f(*args, **kwargs)
[2020-05-06T23:02:37.411Z]   File "/home/osirium_support/****_slave/.cleanup-pipeline-pr-3882-pyenv3/lib/python3.7/site-packages/pyVmomi/VmomiSupport.py", line 520, in _InvokeAccessor
[2020-05-06T23:02:37.411Z]     return self._stub.InvokeAccessor(self, info)
[2020-05-06T23:02:37.411Z]   File "/home/osirium_support/****_slave/.cleanup-pipeline-pr-3882-pyenv3/lib/python3.7/site-packages/pyVmomi/StubAdapterAccessorImpl.py", line 42, in InvokeAccessor
[2020-05-06T23:02:37.411Z]     options=self._pcType.RetrieveOptions(maxObjects=1))
[2020-05-06T23:02:37.411Z]   File "/home/osirium_support/****_slave/.cleanup-pipeline-pr-3882-pyenv3/lib/python3.7/site-packages/pyVmomi/VmomiSupport.py", line 706, in <lambda>
[2020-05-06T23:02:37.411Z]     self.f(*(self.args + (obj,) + args), **kwargs)
[2020-05-06T23:02:37.411Z]   File "/home/osirium_support/****_slave/.cleanup-pipeline-pr-3882-pyenv3/lib/python3.7/site-packages/pyVmomi/VmomiSupport.py", line 512, in _InvokeMethod
[2020-05-06T23:02:37.411Z]     return self._stub.InvokeMethod(self, info, args)
[2020-05-06T23:02:37.411Z]   File "/home/osirium_support/****_slave/.cleanup-pipeline-pr-3882-pyenv3/lib/python3.7/site-packages/pyVmomi/SoapAdapter.py", line 1397, in InvokeMethod
[2020-05-06T23:02:37.411Z]     raise obj # pylint: disable-msg=E0702
[2020-05-06T23:02:37.411Z] pyVmomi.VmomiSupport.ManagedObjectNotFound: (vmodl.fault.ManagedObjectNotFound) {
[2020-05-06T23:02:37.411Z]    dynamicType = <unset>,
[2020-05-06T23:02:37.411Z]    dynamicProperty = (vmodl.DynamicProperty) [],
[2020-05-06T23:02:37.411Z]    msg = "The object 'vim.VirtualMachine:vm-154274' has already been deleted or has not been completely created",
[2020-05-06T23:02:37.411Z]    faultCause = <unset>,
[2020-05-06T23:02:37.411Z]    faultMessage = (vmodl.LocalizableMessage) [],
[2020-05-06T23:02:37.411Z]    obj = 'vim.VirtualMachine:vm-154274'
[2020-05-06T23:02:37.411Z] }
```