### PR TITLE
Added Vsphere Session Idle timeout config option

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,8 @@ Versioning <http://semver.org/>`__.
 5.1.2rc1 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Added vcdriver_idle_timeout option to "Vsphere Session" section of INI config file.
+  The default is 7200 seconds and can now be changed via INI config file.
 
 
 [4.3.0] - 2018-07-06

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -38,6 +38,7 @@ def config_file(path, prepopulated_data=None):
     config.set('Vsphere Session', 'vcdriver_port', '443')
     config.set('Vsphere Session', 'vcdriver_username', '')
     config.set('Vsphere Session', 'vcdriver_password', '')
+    config.set('Vsphere Session', 'vcdriver_idle_timeout', '7200')
     config.add_section('Virtual Machine Deployment')
     config.set(
         'Virtual Machine Deployment',
@@ -102,7 +103,8 @@ def test_read(config_files):
             'vcdriver_host': '',
             'vcdriver_port': '443',
             'vcdriver_username': '',
-            'vcdriver_password': ''
+            'vcdriver_password': '',
+            'vcdriver_idle_timeout': '7200'
         },
         'Virtual Machine Deployment': {
             'vcdriver_resource_pool': '',
@@ -123,7 +125,8 @@ def test_read(config_files):
             'vcdriver_host': '',
             'vcdriver_port': '443',
             'vcdriver_username': '',
-            'vcdriver_password': 'myway'
+            'vcdriver_password': 'myway',
+            'vcdriver_idle_timeout': '7200'
         },
         'Virtual Machine Deployment': {
             'vcdriver_resource_pool': '',

--- a/vcdriver/config.py
+++ b/vcdriver/config.py
@@ -15,7 +15,8 @@ _CONFIG = {
         'vcdriver_host': '',
         'vcdriver_port': _DEFAULTS['vcdriver_port'],
         'vcdriver_username': '',
-        'vcdriver_password': ''
+        'vcdriver_password': '',
+        'vcdriver_idle_timeout': '7200'
     },
     'Virtual Machine Deployment': {
         'vcdriver_resource_pool': '',

--- a/vcdriver/session.py
+++ b/vcdriver/session.py
@@ -25,6 +25,7 @@ def close():
     ('Vsphere Session', 'vcdriver_port'),
     ('Vsphere Session', 'vcdriver_username'),
     ('Vsphere Session', 'vcdriver_password'),
+    ('Vsphere Session', 'vcdriver_idle_timeout'),
 ])
 def connection(**kwargs):
     """ Open the session if it does not exist and return the connection """
@@ -37,6 +38,7 @@ def connection(**kwargs):
             port=kwargs['vcdriver_port'],
             user=kwargs['vcdriver_username'],
             pwd=kwargs['vcdriver_password'],
+            connectionPoolTimeout=int(kwargs['vcdriver_idle_timeout']),
             sslContext=context
         )
         _session_id = _connection_obj.content.sessionManager.currentSession.key


### PR DESCRIPTION
On osirium-main CI sometimes we see failure due to "vSphere unauthenticated" exception.
After investigating, we found out that is due to idle timeout defaulting to 900 on  pyvmomi library.
This PR increases to 7200 as default and add an option to change it via INI file.
