### PR TITLE
Improve reliability of test_read with reset before running

### DIFF
--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -98,6 +98,7 @@ def config_files():
 
 
 def test_read(config_files):
+    reset()
     assert read() == {
         'Vsphere Session': {
             'vcdriver_host': '',


### PR DESCRIPTION
This PR aims to improve the reliability of the test `test_read` by resetting the state before running the test.

The test may fail in the following way if it starts running from a polluted state:
```
    def test_read(config_files):
>       assert read() == {
 ......
E       AssertionError: assert {'Virtual Mac...: '443', ...}} == {'Virtual Mac...: '443', ...}}
E         Omitting 2 identical items, use -vv to show
E         Differing items:
E         {'Vsphere Session': {'vcdriver_host': '', 'vcdriver_idle_timeout': '7200', 'vcdriver_password': 'myway', 'vcdriver_port
': '443', ...}} != {'Vsphere Session': {'vcdriver_host': '', 'vcdriver_idle_timeout': '7200', 'vcdriver_password': '', 'vcdriver_
port': '443', ...}}
E         Use -v to get the full diff
```